### PR TITLE
Fix AD IOC

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -15,8 +15,8 @@
 # docker compose up --detach
 
 include:
-  - services/MOTOR_docker_image/compose.yml
-  - services/PE_docker_image/compose.yml
+  - services/motor_sim_docker_image/compose.yml
+  - services/ad_sim_docker_image/compose.yml
   - services/gateway/compose.yml
   - services/pvagw/compose.yml
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,6 +26,7 @@ include:
 services:
   init:
     image: ubuntu:latest
+    platform: linux/amd64
     security_opt:
       - label=disable
     restart: no

--- a/services/.ioc_template/compose.yml
+++ b/services/.ioc_template/compose.yml
@@ -7,7 +7,7 @@ services:
       file: ../../include/ioc.yml
 
     image: replace_with_image_uri
-
+    platform: linux/amd64
     labels:
       version: 0.1.0
 

--- a/services/ad_sim_docker_image/compose.yml
+++ b/services/ad_sim_docker_image/compose.yml
@@ -7,7 +7,7 @@ services:
       file: ../../include/ioc.yml
 
     image: ghcr.io/epics-containers/ioc-adsimdetector-runtime:2025.3.1
-
+    platform: linux/amd64
     labels:
       version: 0.1.0
 

--- a/services/ad_sim_docker_image/config/ioc.yaml
+++ b/services/ad_sim_docker_image/config/ioc.yaml
@@ -9,8 +9,8 @@ entities:
 
   - type: ADSimDetector.simDetector
     PORT: cam
-    P: "XF:31IDA-BI{Cam:Tbl}" 
-    R: ":cam1:" 
+    P: "XF:31IDA-BI{Cam:Tbl}"
+    R: ":cam1:"
     DATATYPE: 0
     WIDTH: 1024
     HEIGHT: 1024
@@ -78,7 +78,7 @@ entities:
     XSIZE: 1024
     YSIZE: 1024
     HIST_SIZE: 20
-  
+
   - type: ADCore.NDStats
     PORT: Stats3
     P: XF:31IDA-BI{Cam:Tbl}
@@ -127,19 +127,19 @@ entities:
     TIMEOUT: 5.0
 
   - type: ADCore.NDOverlay
+    PORT: Over1
     P: XF:31IDA-BI{Cam:Tbl}
     R: ":Over1:"
-    PORT: Over1
     NDARRAY_PORT: cam
 
   - type: ADCore.NDTransform
+    PORT: TRANS1
     P: XF:31IDA-BI{Cam:Tbl}
     R: ":Trans1:"
-    PORT: EnableCallbacks_RBV
     NDARRAY_PORT: cam
 
-  # - type: ADCore.NDTransform
-  #   P: XF:31IDA-BI{Cam:Tbl}
-  #   R: ":netCDF1:"
-  #   PORT: EnableCallbacks_RBV
-  #   NDARRAY_PORT: cam
+  - type: ADCore.NDFileNetCDF
+    PORT: NetCDF1
+    P: XF:31IDA-BI{Cam:Tbl}
+    R: ":netCDF1:"
+    NDARRAY_PORT: cam

--- a/services/epics-opis/compose.yml
+++ b/services/epics-opis/compose.yml
@@ -9,7 +9,7 @@ services:
 
   epics-opis:
     image: docker.io/nginx:1.27
-
+    platform: linux/amd64
     restart: unless-stopped
 
     networks:

--- a/services/gateway/compose.yml
+++ b/services/gateway/compose.yml
@@ -14,7 +14,7 @@ services:
     container_name: ca-gateway
 
     image: ghcr.io/epics-containers/gateways-developer:2024.12.3
-
+    platform: linux/amd64
     security_opt:
       - label=disable
 
@@ -58,7 +58,7 @@ services:
 
     # this image is not distroless and has network tools installed
     image: ghcr.io/epics-containers/docker-ca-gateway-debug:2.1.3ec1
-
+    platform: linux/amd64
     profiles:
       - debug
 

--- a/services/motor_sim_docker_image/compose.yml
+++ b/services/motor_sim_docker_image/compose.yml
@@ -7,7 +7,7 @@ services:
       file: ../../include/ioc.yml
 
     image: ghcr.io/epics-containers/ioc-motorsim-runtime:2024.9.1
-
+    platform: linux/amd64
     labels:
       version: 0.1.0
 

--- a/services/pvagw/compose.yml
+++ b/services/pvagw/compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: pvagw
 
     image: ghcr.io/epics-containers/gateways-developer:2024.12.3
-
+    platform: linux/amd64
     depends_on:
       - init
 


### PR DESCRIPTION
These updates should fix the IOC config (NetCDF port, etc.) and add the linux/amd64 platform to work on macOS with Podman without special tricks.